### PR TITLE
Router cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
-jobs:
-  include:
-    - language: python
-      python: 3.6
-      node_js: 8
-      install:
-        - cd router
-        - npm install
-        - npm run-script build
-        - cd ../config
-        - pip install -r requirements.txt
-        - pip install -r test_requirements.txt
-      script:
-        - pytest test.py
-        - npm test
+language: python
+python: 3.6
+install:
+  - cd router
+  - npm install
+  - npm run-script build
+  - cd ../config
+  - pip install -r requirements.txt
+  - pip install -r test_requirements.txt
+script:
+  - pytest test.py
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,14 @@ jobs:
   include:
     - language: python
       python: 3.6
-      install:
-        - cd config
-        - pip install -r requirements.txt
-        - pip install -r test_requirements.txt
-      script:
-        - pytest test.py
-    - language: node
-      node_js:
-        - "8"
+      node_js: 8
       install:
         - cd router
         - npm install
         - npm run-script build
+        - cd ../config
+        - pip install -r requirements.txt
+        - pip install -r test_requirements.txt
       script:
+        - pytest test.py
         - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: 3.6
+node_js: 8
 install:
   - cd router
   - npm install
@@ -9,4 +10,5 @@ install:
   - pip install -r test_requirements.txt
 script:
   - pytest test.py
+  - cd ../router
   - npm test

--- a/router/package-lock.json
+++ b/router/package-lock.json
@@ -1,9 +1,15 @@
 {
-  "name": "router",
+  "name": "webhook-router",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/argparse": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.33.tgz",
+      "integrity": "sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==",
+      "dev": true
+    },
     "@types/http-proxy": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.12.1.tgz",
@@ -34,6 +40,36 @@
         "@types/node": "8.0.33"
       }
     },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-flatten": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+    },
+    "async": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "requires": {
+        "lodash": "4.16.2"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -50,11 +86,47 @@
         "concat-map": "0.0.1"
       }
     },
+    "btoa": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz",
+      "integrity": "sha1-PkC4FmP4HS3WWWpMtxSo3BbPq+A="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "encoding": {
       "version": "0.1.12",
@@ -63,6 +135,11 @@
       "requires": {
         "iconv-lite": "0.4.19"
       }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -74,6 +151,21 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
+    },
+    "fast-json-patch": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-1.1.8.tgz",
+      "integrity": "sha1-jbWMnRLD/5wjRW7oEswp+scit3I="
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "requires": {
+        "async": "2.5.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -130,6 +222,23 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "isomorphic-form-data": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-0.0.1.tgz",
+      "integrity": "sha1-Am9ifgMrDNhBPsyHVZKLlKRosGI=",
+      "requires": {
+        "form-data": "1.0.1"
+      }
+    },
     "jasmine": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
@@ -147,6 +256,38 @@
       "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
       "dev": true
     },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz",
+      "integrity": "sha1-PmJtuCcEimmSgaihJSJjJs/A5lI="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -155,6 +296,11 @@
       "requires": {
         "brace-expansion": "1.1.8"
       }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -174,22 +320,112 @@
         "wrappy": "1.0.2"
       }
     },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/router/-/router-1.3.2.tgz",
+      "integrity": "sha1-v6oWiIpSg9XuQNmZ2nqfoVKWpgw=",
+      "requires": {
+        "array-flatten": "2.1.1",
+        "debug": "2.6.9",
+        "methods": "1.1.2",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "setprototypeof": "1.1.0",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "swagger-client": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.2.2.tgz",
+      "integrity": "sha1-xHDretdPDo56hQ3DjPQaeEIg9oA=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "btoa": "1.1.2",
+        "deep-extend": "0.4.2",
+        "fast-json-patch": "1.1.8",
+        "isomorphic-fetch": "2.2.1",
+        "isomorphic-form-data": "0.0.1",
+        "js-yaml": "3.10.0",
+        "lodash": "4.16.2",
+        "qs": "6.5.1",
+        "url": "0.11.0"
+      }
     },
     "typescript": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
       "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/router/package-lock.json
+++ b/router/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/http-proxy": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.12.1.tgz",
+      "integrity": "sha512-l5OZ8aMZQF1j620+bUGvWT9cjLoxP8bA/wi36xLkNyNLlM9huIVije21hjsbq1NEVJCt0wZpASsDKP0V6EM3FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.33"
+      }
+    },
     "@types/jasmine": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.6.0.tgz",
@@ -55,6 +64,11 @@
         "iconv-lite": "0.4.19"
       }
     },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -79,6 +93,15 @@
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
+      }
+    },
+    "http-proxy": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "iconv-lite": {
@@ -156,6 +179,11 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "typescript": {
       "version": "2.5.3",

--- a/router/package.json
+++ b/router/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "router",
+  "name": "webhook-router",
   "version": "0.1.0",
   "description": "Webhook router",
   "main": "router.js",
@@ -15,10 +15,14 @@
   "author": "Thomas Hickman",
   "license": "MIT",
   "dependencies": {
+    "argparse": "^1.0.9",
     "http-proxy": "^1.16.2",
-    "node-fetch": "^1.7.3"
+    "node-fetch": "^1.7.3",
+    "router": "^1.3.2",
+    "swagger-client": "^3.2.2"
   },
   "devDependencies": {
+    "@types/argparse": "^1.0.33",
     "@types/http-proxy": "^1.12.1",
     "@types/jasmine": "^2.6.0",
     "@types/node": "^8.0.33",

--- a/router/package.json
+++ b/router/package.json
@@ -18,8 +18,7 @@
     "argparse": "^1.0.9",
     "http-proxy": "^1.16.2",
     "node-fetch": "^1.7.3",
-    "router": "^1.3.2",
-    "swagger-client": "^3.2.2"
+    "router": "^1.3.2"
   },
   "devDependencies": {
     "@types/argparse": "^1.0.33",

--- a/router/package.json
+++ b/router/package.json
@@ -15,9 +15,11 @@
   "author": "Thomas Hickman",
   "license": "MIT",
   "dependencies": {
+    "http-proxy": "^1.16.2",
     "node-fetch": "^1.7.3"
   },
   "devDependencies": {
+    "@types/http-proxy": "^1.12.1",
     "@types/jasmine": "^2.6.0",
     "@types/node": "^8.0.33",
     "@types/node-fetch": "^1.6.7",

--- a/router/router.ts
+++ b/router/router.ts
@@ -2,6 +2,7 @@ import http = require('http');
 import https = require('https');
 import url = require("url");
 import fetch from "node-fetch";
+import httpProxy = require("http-proxy")
 
 const configServer = "http://127.0.0.1:8081"
 
@@ -23,68 +24,6 @@ class RoutingException extends Error{
     }
 }
 
-export function routeRequest(request: http.IncomingMessage, response: http.ServerResponse, destination: string){
-    return new Promise((resolve, reject) => {
-        let parsedUrl = url.parse(destination);
-        
-        var httpProtocol = http; // for the type checker
-        if (parsedUrl.protocol == "http:"){
-            httpProtocol = http;
-        }
-        else if (parsedUrl.protocol == "https:"){
-            httpProtocol = <any>https;
-        }
-        else{
-            throw new RoutingException("Invalid client protocol", 400);
-        }
-
-        // have to use `.rawHeaders` as `.headers` makes all properties lower case 
-        var headers = <any>{};
-        for(var i = 0;i < request.rawHeaders.length;i += 2){
-            let headerKey = request.rawHeaders[i];
-            if(headerKey.toLowerCase() != "host"){ // let node.js set this
-                // hope there are no duplicate headers, otherwise they'll be overwritten
-                headers[headerKey] = request.rawHeaders[i + 1];
-            }
-        }
-
-        var forwardedReq = httpProtocol.request(<any>{
-            ...parsedUrl,
-            method: "POST",
-            headers: {
-                ...headers
-            }
-        }, (forwardedResp) => {
-            forwardedResp.addListener("data", (chunk) => {
-                response.write(chunk, 'binary');
-            })
-
-            forwardedResp.addListener("end", () => {
-                response.end();
-                resolve();
-            })
-
-            response.writeHead(<number>forwardedResp.statusCode, forwardedResp.headers);
-        });
-
-        forwardedReq.addListener("error", (e) => {
-            reject(new RoutingException("Cannot connect to server", 500, e.toString()))
-        })
-
-        request.addListener('data', (chunk) => {
-            forwardedReq.write(chunk, 'binary');
-        });
-
-        request.addListener('end', () => {
-            forwardedReq.end();
-        });
-
-        request.addListener('error', (e) => {
-            reject(e);
-        })
-    })
-}
-
 async function getDestinationFromToken(token: string){
     var configServerResp = await fetch(`${configServer}/routes/${token}`)
     try{
@@ -98,10 +37,14 @@ async function getDestinationFromToken(token: string){
         throw new RoutingException("Config server error: " + configServerJSON.error, configServerResp.status);
     }
 
-    return configServerJSON.destination;
+    return <string>configServerJSON.destination;
 }
 
-async function handleRequest(request: http.IncomingMessage, response: http.ServerResponse){
+let proxy = httpProxy.createProxyServer({
+    changeOrigin: true
+})
+
+function handleRequest(request: http.IncomingMessage, response: http.ServerResponse, onError: (error: any) => any){
     // see if the request is correct and extract the token
     // should be POST request of the form /{token}
     let requestUrl = url.parse(<string>request.url);
@@ -115,25 +58,34 @@ async function handleRequest(request: http.IncomingMessage, response: http.Serve
         return;
     }
 
-    await routeRequest(request, response, await getDestinationFromToken(path[0]));
+    getDestinationFromToken(path[0]).then((destination) => {
+        proxy.web(request, response, {
+            target: destination
+        }, (error) => {
+            onError(error)
+        })
+    }).catch((error) => {
+        onError(error)
+    })
 }
 
+proxy.on("end", (req, res, proxyRes) => {
+    // TODO: log successful route
+})
+
 http.createServer(async (request, response) => {
-    try{
-        await handleRequest(request, response);
-    }
-    catch(e){
-        if (e instanceof RoutingException){
-            if (e.logMessage){
-                console.log(e.logMessage);
+    handleRequest(request, response, (error) => {
+        if (error instanceof RoutingException){
+            if (error.logMessage){
+                console.log(error.logMessage);
             }
-            writeError(e.message, e.httpErrorCode, response);
+            writeError(error.message, error.httpErrorCode, response);
         }
         else{
             writeError("Internal Server Error", 500, response);
-            console.log(e);
+            console.log(error);
         }
-    }
+    });
 }).listen(8080);
 
 process.on('uncaughtException', function (err) {

--- a/router/router.ts
+++ b/router/router.ts
@@ -11,11 +11,7 @@ function writeError(message: string, code: number, response: http.ServerResponse
         "Content-Type": "application/json; charset=utf-8"
     })
 
-    response.end(
-`{
-    "error": "${message}"
-}
-`)
+    response.end(JSON.stringify({error: message}))
 }
 
 class RoutingException extends Error{

--- a/router/test.ts
+++ b/router/test.ts
@@ -1,45 +1,80 @@
 import cp = require("child_process");
-import {routeRequest} from "./router";
 import http = require("http")
+import os = require("os");
+import fetch from "node-fetch";
 
-function logOutput(error: Error, stdout: string, stderr: string){
-    if(error !== null){
-        throw error;
-    }
+var configServer: cp.ChildProcess;
+var routerServer: cp.ChildProcess;
 
-    if(stdout !== ""){
-        console.log(stdout);
-    }
+var [configPort, routerPort, receiverPort] = [8080, 8081, 8082];
 
-    if(stderr !== ""){
-        console.error(stderr);
-    }
+function delay(time: number){
+    return new Promise((resolve, reject) => {
+        setTimeout(resolve, time);
+    })
 }
 
-it("routes correctly", (finish) => {
-    var got_route = false;
+beforeAll(async () => {
+    configServer = cp.spawn(`python ../config/server.py --port ${configPort} --host 127.0.0.1 --debug`, 
+        [], {shell: true, stdio: "inherit"});
+    routerServer = cp.spawn(`node ./router.js --port ${routerPort} --host 127.0.0.1 --configServer http://127.0.0.1:${configPort}`,
+        [], {shell: true, stdio: "inherit"});
+    await delay(5000);
+}, 5500)
+
+async function addRoute(dest: string){
+    let addRouteResp = await fetch(`http://127.0.0.1:${configPort}/add-route`, {
+        method: "POST",
+        body: JSON.stringify({
+            name: "route",
+            destination: dest
+        }),
+        headers: {
+            "Content-Type": "application/json"
+        }
+    })
+
+    let token: string = (await addRouteResp.json()).token;
+    expect(token).not.toBeUndefined;
+
+    return token;
+}
+
+async function testRoutingToAddress(location: string){
+    let token = await addRoute(location);
+    
+    return await fetch(`http://127.0.0.1:${routerPort}/${token}`, {
+        method: "POST"
+    })
+}
+
+it("Routes to test server", async () => {
     http.createServer((req, res) => {
         res.end("response");
-        got_route = true;
-    }).listen(3001);
+    }).listen(receiverPort, "127.0.0.1");
 
-    routeRequest(<any>{
-        rawHeaders: {
-            x: "y"
-        },
-        addListener: (type: string, func: () => void) => {
-            if(type == "end"){
-                func()
-            }
-        }
-    }, <any>{
-        write: () => {
-        },
-        writeHead: () => {
-        },
-        end: () => {
-            if(got_route)
-                finish()
-        }
-    }, "http://127.0.0.1:3001")
+    let resp = await testRoutingToAddress(`127.0.0.1:${receiverPort}`)
+
+    expect(await resp.text()).toBe("response");
 });
+
+describe("example.com", () => {
+    it("routes to http", async () => {
+        let resp = await testRoutingToAddress("http://www.example.com")
+
+        expect(await resp.text()).toBeTruthy;
+        expect(resp.status).toEqual(200);
+    })
+
+    it("routes to https", async () => {
+        let resp = await testRoutingToAddress("https://www.example.com")
+
+        expect(await resp.text()).toBeTruthy;
+        expect(resp.status).toEqual(200);
+    })
+})
+
+afterAll(() => {
+    configServer.kill();
+    routerServer.kill();
+})


### PR DESCRIPTION
Improved the router code, implementing suggestions by @Xophmeister 

1. This now uses the packages [http-proxy](https://www.npmjs.com/package/http-proxy) for routing the request and [router](https://www.npmjs.com/package/router) for routing requests
2. Small code changes that were suggested have been implemented
3. The test of the routing function has been replaced by integration tests, that test routing to a test server and http://www.example.com and https://www.example.com. Travis-CI now tests this, due to #2 
4. Make the server configurable using command line options